### PR TITLE
Basic mcpc+/forge world support.

### DIFF
--- a/src/main/java/me/eccentric_nz/TARDIS/builders/TARDISBuilderPoliceBox.java
+++ b/src/main/java/me/eccentric_nz/TARDIS/builders/TARDISBuilderPoliceBox.java
@@ -178,7 +178,8 @@ public class TARDISBuilderPoliceBox {
                 StringBuilder sb = new StringBuilder();
                 for (Block pb : platform_blocks) {
                     Material mat = pb.getType();
-                    if (mat == Material.AIR || mat == Material.STATIONARY_WATER || mat == Material.WATER || mat == Material.VINE || mat == Material.RED_MUSHROOM || mat == Material.BROWN_MUSHROOM || mat == Material.LONG_GRASS || mat == Material.SAPLING || mat == Material.DEAD_BUSH || mat == Material.RED_ROSE || mat == Material.YELLOW_FLOWER || mat == Material.SNOW) {
+                    int matint = pb.getTypeId();
+                    if (matint == 0 || matint == 9 || matint == 8 || matint == 106 || matint == 40 || matint == 39 || matint== 31 || matint== 6 || matint== 32 || matint== 38 || matint== 37 || matint== 78 || matint== 3019 || matint== 3020) {
                         if (rebuild) {
                             plugin.utils.setBlockAndRemember(world, pb.getX(), pb.getY(), pb.getZ(), platform_id, grey, id);
                         } else {

--- a/src/main/java/me/eccentric_nz/TARDIS/commands/TARDISTravelCommands.java
+++ b/src/main/java/me/eccentric_nz/TARDIS/commands/TARDISTravelCommands.java
@@ -472,7 +472,8 @@ public class TARDISTravelCommands implements CommandExecutor {
         int startx = p.getLocation().getBlockX();
         int startz = p.getLocation().getBlockZ();
         // get a world
-        if (w != null && w.getEnvironment().equals(Environment.NORMAL)) {
+        // Assume all non-nether/non-end world environments are NORMAL
+        if (w != null && !w.getEnvironment().equals(Environment.NETHER) && !w.getEnvironment().equals(Environment.NETHER)) {
             int limitx = 30000;
             int limitz = 30000;
             if (plugin.pm.isPluginEnabled("WorldBorder")) {

--- a/src/main/java/me/eccentric_nz/TARDIS/travel/TARDISTimeTravel.java
+++ b/src/main/java/me/eccentric_nz/TARDIS/travel/TARDISTimeTravel.java
@@ -106,6 +106,10 @@ public class TARDISTimeTravel {
                 World ww = plugin.getServer().getWorld(o);
                 if (ww != null) {
                     String env = ww.getEnvironment().toString();
+                    // Catch all non-nether and non-end ENVIRONMENT types and assume they're normal
+                    if (env != "NETHER" && env != "THE_END") {
+                        env = "NORMAL";
+                    }
                     if (e.equalsIgnoreCase(env)) {
                         if (plugin.getConfig().getBoolean("include_default_world") || !plugin.getConfig().getBoolean("default_world")) {
                             if (plugin.getConfig().getBoolean("worlds." + o) || malfunction) {
@@ -187,7 +191,8 @@ public class TARDISTimeTravel {
             }
             dest = new Location(randworld, wherex, highest, wherez);
         }
-        if (randworld != null && randworld.getEnvironment().equals(Environment.NORMAL)) {
+        // Assume every non-nether/non-END world qualifies as NORMAL.  Ideally this could be a config file option, you could put your MCPC+ environments (Tropicraft, twilightforest) as appropriate environment types.
+        if (randworld != null && !randworld.getEnvironment().equals(Environment.NETHER) && !randworld.getEnvironment().equals(Environment.THE_END)) {
             long timeout = System.currentTimeMillis() + (plugin.getConfig().getLong("timeout") * 1000);
             while (danger == true) {
                 if (System.currentTimeMillis() < timeout) {


### PR DESCRIPTION
This allows tardises to travel to modded/non-NORMAL environment dimensions when using MCPC+. It fixes teleportation within these dimensions, and the biome search feature.

It's not pretty, but it seems to work OK.

Something's buggy with commands and entering/exiting tardis, but I don't believe it's related to my changes, it seems to affect a build from original source as well.
