### PR TITLE
Update TARDISSaveLocationCommand.java

### DIFF
--- a/src/main/java/me/eccentric_nz/TARDIS/commands/tardis/TARDISSaveLocationCommand.java
+++ b/src/main/java/me/eccentric_nz/TARDIS/commands/tardis/TARDISSaveLocationCommand.java
@@ -60,6 +60,10 @@ public class TARDISSaveLocationCommand {
                 if (plugin.getConfig().getString("preferences.difficulty").equals("hard")) {
                     tcc = new TARDISCircuitChecker(plugin, id);
                     tcc.getCircuits();
+                    if (tcc == null) {
+                        player.sendMessage(plugin.getPluginName() + "You need to use a Storage Disk! See the " + ChatColor.AQUA + "TARDIS Information System" + ChatColor.RESET + " for help using Disks.");
+                        return true;
+                    }
                 }
                 if (tcc != null && !tcc.hasMemory()) {
                     player.sendMessage(plugin.getPluginName() + MESSAGE.NO_MEM_CIRCUIT.getText());


### PR DESCRIPTION
Attempt to update the /tardis save [name] command to require use of a Disk in Hard mode.  If I'm reading the code right, this should warn the player to use a disk if they attempt to use the /tardis save command on Hard mode with no disk in their hand.
