### PR TITLE
Update TARDISRescue.java

### DIFF
--- a/src/main/java/me/eccentric_nz/TARDIS/travel/TARDISRescue.java
+++ b/src/main/java/me/eccentric_nz/TARDIS/travel/TARDISRescue.java
@@ -94,7 +94,9 @@ public class TARDISRescue {
         where.put("tardis_id", id);
         QueryFactory qf = new QueryFactory(plugin);
         qf.doUpdate("next", set, where);
-        player.sendMessage(plugin.getPluginName() + "The player location was saved successfully.");
+        if (!rescue) {
+            player.sendMessage(plugin.getPluginName() + "The player location was saved successfully. Please release the handbrake!");
+        }
         plugin.getTrackerKeeper().getTrackHasDestination().put(id, plugin.getArtronConfig().getInt("travel"));
         if (rescue) {
             plugin.getTrackerKeeper().getTrackRescue().put(id, saved);


### PR DESCRIPTION
Re-fix redundant rescue messaging to account for /tardistravel player still needing the "release handbrake" message.

I didn't realize that /tardistravel player uses the same code when I adjusted this earlier.  Rescue attempts will still receive a message from TARDISChatListener.java telling the player to release the handbrake, so that should be sufficient.
