### PR TITLE
Update TARDISDoorListener.java

### DIFF
--- a/src/main/java/me/eccentric_nz/TARDIS/listeners/TARDISDoorListener.java
+++ b/src/main/java/me/eccentric_nz/TARDIS/listeners/TARDISDoorListener.java
@@ -187,7 +187,7 @@ public class TARDISDoorListener implements Listener {
                                         return;
                                     }
                                     int locked = (rsd.isLocked()) ? 0 : 1;
-                                    String message = (rsd.isLocked()) ? "unlocked" : "locked";
+                                    String message = (rsd.isLocked()) ? "unlocked" : "deadlocked";
                                     HashMap<String, Object> setl = new HashMap<String, Object>();
                                     setl.put("locked", locked);
                                     HashMap<String, Object> wherel = new HashMap<String, Object>();
@@ -276,7 +276,7 @@ public class TARDISDoorListener implements Listener {
                                 }
                             } else if (action == Action.RIGHT_CLICK_BLOCK) {
                                 if (rsd.isLocked()) {
-                                    TARDISMessage.send(player, plugin.getPluginName() + "The door is locked!");
+                                    TARDISMessage.send(player, plugin.getPluginName() + "The door is deadlocked!");
                                     return;
                                 }
                                 int id = rsd.getTardis_id();


### PR DESCRIPTION
Change TARDIS door "locked" messaging to read "deadlocked" instead.

Question:  Does line 192 also need to be changed or is that a back-end thing to actually set a door as locked?
