### PR TITLE
Update TARDISButtonListener.java

### DIFF
--- a/src/main/java/me/eccentric_nz/TARDIS/listeners/TARDISButtonListener.java
+++ b/src/main/java/me/eccentric_nz/TARDIS/listeners/TARDISButtonListener.java
@@ -307,7 +307,7 @@ public class TARDISButtonListener implements Listener {
                                         TARDISMessage.send(player, plugin.getPluginName() + ChatColor.RED + MESSAGE.NOT_WHILE_TRAVELLING.getText());
                                         return;
                                     }
-                                    if (level < plugin.getArtronConfig().getInt("random")) {
+                                    if (level < plugin.getArtronConfig().getInt("travel")) {
                                         TARDISMessage.send(player, plugin.getPluginName() + ChatColor.RED + MESSAGE.NOT_ENOUGH_ENERGY.getText());
                                         return;
                                     }


### PR DESCRIPTION
When checking for sufficient Artron Energy, the destination Terminal should use the "travel" config value, not "random".

It correctly takes away the "travel" amount when you actually do time travel, it's just not checking whether you have that much artron to use.
