### PR TITLE
Add Discord links & Add links to the header

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,9 +6,13 @@
     <header>
         <h1>{{ site.title }}</h1>
         <p>{{ site.description }}</p>
-        <p class="view"><a href="https://github.com/eccentricdevotion/TARDIS">View the Project on GitHub <small>eccentricdevotion/TARDIS</small></a></p>
+        <p><a href="https://github.com/eccentricdevotion/TARDIS/issues">Leave Bug Reports or Suggestions on GitHub</a></p>
+        <p><a href="https://discord.gg/sfuPVHh">Join our Community Discord server!</a></p>
         <ul>
-            <li><a href="/TARDIS/">Back <strong>home</strong></a></li>
+          {% if page.title contains "Home Page" %}
+          {% else %}
+            <li><a href="/TARDIS/">Back <strong>Home</strong></a></li>
+          {% endif %}
             <li><a href="site-map.html"><strong>Index</strong> File</a></li>
         </ul>
     </header>

--- a/index.md
+++ b/index.md
@@ -1,11 +1,11 @@
 ---
 layout: default
-title: TARDIS
+title: Home Page
 ---
 
 # TARDIS
 
-TARDIS is a CraftBukkit plugin that allows you to create a TARDIS that lets you time travel (teleport) to random locations. It adds a Whovian twist to the typical /sethome and /home commands.
+TARDIS is a Spigot / Paper plugin that allows you to create a TARDIS that lets you time travel (teleport) to random locations. It adds a Whovian twist to the typical /sethome and /home commands.
 
 **As a player, you can:**
 
@@ -24,5 +24,6 @@ TARDIS is a CraftBukkit plugin that allows you to create a TARDIS that lets you 
 
 [Check out some **FAQs**](faqs.html)
 
-![TARDIS](images/docs/artronrecharging.jpg)
+[Join our Community-Led Discord Server!](https://discord.gg/sfuPVHh)
 
+![TARDIS](images/docs/artronrecharging.jpg)


### PR DESCRIPTION
This commit does 2 things:

1) Adds the Discord link to the root /TARDIS page
![image](https://user-images.githubusercontent.com/8278263/77868174-cdb4d180-71ff-11ea-93ef-660ff71fea2f.png)

2) Adds the GitHub and Discord links to the header
![image](https://user-images.githubusercontent.com/8278263/77868166-c7bef080-71ff-11ea-94ba-85b45f575e58.png)

3) Hides the "Go Home" button on the home page (we're already there!)
*Home Page*
![image](https://user-images.githubusercontent.com/8278263/77868187-d9a09380-71ff-11ea-98fa-655f985a16fb.png)
*Any other page*
![image](https://user-images.githubusercontent.com/8278263/77868195-e329fb80-71ff-11ea-9a31-54ed3dd64a15.png)
