### PR TITLE
Add placeholders for current tardis location

### DIFF
--- a/src/main/java/me/eccentric_nz/TARDIS/placeholders/TARDISPlaceholderExpansion.java
+++ b/src/main/java/me/eccentric_nz/TARDIS/placeholders/TARDISPlaceholderExpansion.java
@@ -98,10 +98,8 @@ public class TARDISPlaceholderExpansion extends PlaceholderExpansion {
                     break;
                 case "current_location":
                     rsti = new ResultSetTardisID(plugin);
-                    exist = rsti.fromUUID(uuid);
-                    if (exist) {
-                        int id = rsti.getTardis_id();
-                        where.put("tardis_id", id);
+                    if (rsti.fromUUID(uuid)) {
+                        where.put("tardis_id", rsti.getTardis_id());
                         rscl = new ResultSetCurrentLocation(plugin, where);
                         if (rscl.resultSet()) {
                             result = "TARDIS was left at " + rscl.getWorld().getName() + " at " + "x: " + rscl.getX() + " y: " + rscl.getY() + " z: " + rscl.getZ();
@@ -110,10 +108,8 @@ public class TARDISPlaceholderExpansion extends PlaceholderExpansion {
                     break;
                 case "current_location_x":
                     rsti = new ResultSetTardisID(plugin);
-                    exist = rsti.fromUUID(uuid);
-                    if (exist) {
-                        int id = rsti.getTardis_id();
-                        where.put("tardis_id", id);
+                    if (rsti.fromUUID(uuid)) {
+                        where.put("tardis_id", rsti.getTardis_id());
                         rscl = new ResultSetCurrentLocation(plugin, where);
                         if (rscl.resultSet()) {
                             result = rscl.getX() + "";
@@ -122,10 +118,8 @@ public class TARDISPlaceholderExpansion extends PlaceholderExpansion {
                     break;
                 case "current_location_y":
                     rsti = new ResultSetTardisID(plugin);
-                    exist = rsti.fromUUID(uuid);
-                    if (exist) {
-                        int id = rsti.getTardis_id();
-                        where.put("tardis_id", id);
+                    if (rsti.fromUUID(uuid)) {
+                        where.put("tardis_id", rsti.getTardis_id());
                         rscl = new ResultSetCurrentLocation(plugin, where);
                         if (rscl.resultSet()) {
                             result = rscl.getY() + "";
@@ -134,10 +128,8 @@ public class TARDISPlaceholderExpansion extends PlaceholderExpansion {
                     break;
                 case "current_location_z":
                     rsti = new ResultSetTardisID(plugin);
-                    exist = rsti.fromUUID(uuid);
-                    if (exist) {
-                        int id = rsti.getTardis_id();
-                        where.put("tardis_id", id);
+                    if (rsti.fromUUID(uuid)) {
+                        where.put("tardis_id", rsti.getTardis_id());
                         rscl = new ResultSetCurrentLocation(plugin, where);
                         if (rscl.resultSet()) {
                             result = rscl.getZ() + "";
@@ -146,10 +138,8 @@ public class TARDISPlaceholderExpansion extends PlaceholderExpansion {
                     break;
                 case "current_location_world":
                     rsti = new ResultSetTardisID(plugin);
-                    exist = rsti.fromUUID(uuid);
-                    if (exist) {
-                        int id = rsti.getTardis_id();
-                        where.put("tardis_id", id);
+                    if (rsti.fromUUID(uuid)) {
+                        where.put("tardis_id", rsti.getTardis_id());
                         rscl = new ResultSetCurrentLocation(plugin, where);
                         if (rscl.resultSet()) {
                             result = rscl.getWorld().getName() + "";
@@ -158,10 +148,8 @@ public class TARDISPlaceholderExpansion extends PlaceholderExpansion {
                     break;
                 case "current_location_direction":
                     rsti = new ResultSetTardisID(plugin);
-                    exist = rsti.fromUUID(uuid);
-                    if (exist) {
-                        int id = rsti.getTardis_id();
-                        where.put("tardis_id", id);
+                    if (rsti.fromUUID(uuid)) {
+                        where.put("tardis_id", rsti.getTardis_id());
                         rscl = new ResultSetCurrentLocation(plugin, where);
                         if (rscl.resultSet()) {
                             result = rscl.getDirection() + "";
@@ -170,10 +158,8 @@ public class TARDISPlaceholderExpansion extends PlaceholderExpansion {
                     break;
                 case "current_location_biome":
                     rsti = new ResultSetTardisID(plugin);
-                    exist = rsti.fromUUID(uuid);
-                    if (exist) {
-                        int id = rsti.getTardis_id();
-                        where.put("tardis_id", id);
+                    if (rsti.fromUUID(uuid)) {
+                        where.put("tardis_id", rsti.getTardis_id());
                         rscl = new ResultSetCurrentLocation(plugin, where);
                         if (rscl.resultSet()) {
                             result = rscl.getBiome() + "";

--- a/src/main/java/me/eccentric_nz/TARDIS/placeholders/TARDISPlaceholderExpansion.java
+++ b/src/main/java/me/eccentric_nz/TARDIS/placeholders/TARDISPlaceholderExpansion.java
@@ -6,6 +6,7 @@ import me.eccentric_nz.TARDIS.database.ResultSetArtronLevel;
 import me.eccentric_nz.TARDIS.database.ResultSetCurrentLocation;
 import me.eccentric_nz.TARDIS.database.ResultSetPlayerPrefs;
 import me.eccentric_nz.TARDIS.database.ResultSetTardis;
+import me.eccentric_nz.TARDIS.database.ResultSetTardisID;
 import me.eccentric_nz.TARDIS.utility.TARDISStringUtils;
 import org.bukkit.entity.Player;
 
@@ -65,6 +66,9 @@ public class TARDISPlaceholderExpansion extends PlaceholderExpansion {
             ResultSetArtronLevel rsl;
             ResultSetTardis rst;
             HashMap<String, Object> where = new HashMap<>();
+            boolean exist;
+            ResultSetTardisID rsti;
+            ResultSetCurrentLocation rscl;
             switch (identifier) {
                 case "artron_amount":
                     rsl = new ResultSetArtronLevel(plugin, uuid);
@@ -93,91 +97,84 @@ public class TARDISPlaceholderExpansion extends PlaceholderExpansion {
                     }
                     break;
                 case "current_location":
-                    where.put("uuid", uuid);
-                    rst = new ResultSetTardis(plugin, where, "", false, 2);
-                    if (rst.resultSet()) {
-                        int id = rst.getTardis().getTardis_id();
-                        where.remove("uuid");
+                    rsti = new ResultSetTardisID(plugin);
+                    exist = rsti.fromUUID(uuid);
+                    if (exist) {
+                        int id = rsti.getTardis_id();
                         where.put("tardis_id", id);
-                        ResultSetCurrentLocation rscl = new ResultSetCurrentLocation(plugin, where);
+                        rscl = new ResultSetCurrentLocation(plugin, where);
                         if (rscl.resultSet()) {
                             result = "TARDIS was left at " + rscl.getWorld().getName() + " at " + "x: " + rscl.getX() + " y: " + rscl.getY() + " z: " + rscl.getZ();
                         }
                     }
                     break;
                 case "current_location_x":
-                    where.put("uuid", uuid);
-                    rst = new ResultSetTardis(plugin, where, "", false, 2);
-                    if (rst.resultSet()) {
-                        int id = rst.getTardis().getTardis_id();
-                        where.remove("uuid");
+                    rsti = new ResultSetTardisID(plugin);
+                    exist = rsti.fromUUID(uuid);
+                    if (exist) {
+                        int id = rsti.getTardis_id();
                         where.put("tardis_id", id);
-                        ResultSetCurrentLocation rscl = new ResultSetCurrentLocation(plugin, where);
+                        rscl = new ResultSetCurrentLocation(plugin, where);
                         if (rscl.resultSet()) {
                             result = rscl.getX() + "";
                         }
                     }
                     break;
                 case "current_location_y":
-                    where.put("uuid", uuid);
-                    rst = new ResultSetTardis(plugin, where, "", false, 2);
-                    if (rst.resultSet()) {
-                        int id = rst.getTardis().getTardis_id();
-                        where.remove("uuid");
+                    rsti = new ResultSetTardisID(plugin);
+                    exist = rsti.fromUUID(uuid);
+                    if (exist) {
+                        int id = rsti.getTardis_id();
                         where.put("tardis_id", id);
-                        ResultSetCurrentLocation rscl = new ResultSetCurrentLocation(plugin, where);
+                        rscl = new ResultSetCurrentLocation(plugin, where);
                         if (rscl.resultSet()) {
                             result = rscl.getY() + "";
                         }
                     }
                     break;
                 case "current_location_z":
-                    where.put("uuid", uuid);
-                    rst = new ResultSetTardis(plugin, where, "", false, 2);
-                    if (rst.resultSet()) {
-                        int id = rst.getTardis().getTardis_id();
-                        where.remove("uuid");
+                    rsti = new ResultSetTardisID(plugin);
+                    exist = rsti.fromUUID(uuid);
+                    if (exist) {
+                        int id = rsti.getTardis_id();
                         where.put("tardis_id", id);
-                        ResultSetCurrentLocation rscl = new ResultSetCurrentLocation(plugin, where);
+                        rscl = new ResultSetCurrentLocation(plugin, where);
                         if (rscl.resultSet()) {
                             result = rscl.getZ() + "";
                         }
                     }
                     break;
                 case "current_location_world":
-                    where.put("uuid", uuid);
-                    rst = new ResultSetTardis(plugin, where, "", false, 2);
-                    if (rst.resultSet()) {
-                        int id = rst.getTardis().getTardis_id();
-                        where.remove("uuid");
+                    rsti = new ResultSetTardisID(plugin);
+                    exist = rsti.fromUUID(uuid);
+                    if (exist) {
+                        int id = rsti.getTardis_id();
                         where.put("tardis_id", id);
-                        ResultSetCurrentLocation rscl = new ResultSetCurrentLocation(plugin, where);
+                        rscl = new ResultSetCurrentLocation(plugin, where);
                         if (rscl.resultSet()) {
                             result = rscl.getWorld().getName() + "";
                         }
                     }
                     break;
                 case "current_location_direction":
-                    where.put("uuid", uuid);
-                    rst = new ResultSetTardis(plugin, where, "", false, 2);
-                    if (rst.resultSet()) {
-                        int id = rst.getTardis().getTardis_id();
-                        where.remove("uuid");
+                    rsti = new ResultSetTardisID(plugin);
+                    exist = rsti.fromUUID(uuid);
+                    if (exist) {
+                        int id = rsti.getTardis_id();
                         where.put("tardis_id", id);
-                        ResultSetCurrentLocation rscl = new ResultSetCurrentLocation(plugin, where);
+                        rscl = new ResultSetCurrentLocation(plugin, where);
                         if (rscl.resultSet()) {
                             result = rscl.getDirection() + "";
                         }
                     }
                     break;
                 case "current_location_biome":
-                    where.put("uuid", uuid);
-                    rst = new ResultSetTardis(plugin, where, "", false, 2);
-                    if (rst.resultSet()) {
-                        int id = rst.getTardis().getTardis_id();
-                        where.remove("uuid");
+                    rsti = new ResultSetTardisID(plugin);
+                    exist = rsti.fromUUID(uuid);
+                    if (exist) {
+                        int id = rsti.getTardis_id();
                         where.put("tardis_id", id);
-                        ResultSetCurrentLocation rscl = new ResultSetCurrentLocation(plugin, where);
+                        rscl = new ResultSetCurrentLocation(plugin, where);
                         if (rscl.resultSet()) {
                             result = rscl.getBiome() + "";
                         }

--- a/src/main/java/me/eccentric_nz/TARDIS/placeholders/TARDISPlaceholderExpansion.java
+++ b/src/main/java/me/eccentric_nz/TARDIS/placeholders/TARDISPlaceholderExpansion.java
@@ -3,6 +3,7 @@ package me.eccentric_nz.TARDIS.placeholders;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
 import me.eccentric_nz.TARDIS.TARDIS;
 import me.eccentric_nz.TARDIS.database.ResultSetArtronLevel;
+import me.eccentric_nz.TARDIS.database.ResultSetCurrentLocation;
 import me.eccentric_nz.TARDIS.database.ResultSetPlayerPrefs;
 import me.eccentric_nz.TARDIS.database.ResultSetTardis;
 import me.eccentric_nz.TARDIS.utility.TARDISStringUtils;
@@ -89,6 +90,97 @@ public class TARDISPlaceholderExpansion extends PlaceholderExpansion {
                     rst = new ResultSetTardis(plugin, where, "", false, 2);
                     if (rst.resultSet()) {
                         result = rst.getTardis().getPreset().toString();
+                    }
+                    break;
+                case "current_location":
+                    where.put("uuid", uuid);
+                    rst = new ResultSetTardis(plugin, where, "", false, 2);
+                    if (rst.resultSet()) {
+                        int id = rst.getTardis().getTardis_id();
+                        where.remove("uuid");
+                        where.put("tardis_id", id);
+                        ResultSetCurrentLocation rscl = new ResultSetCurrentLocation(plugin, where);
+                        if (rscl.resultSet()) {
+                            result = "TARDIS was left at " + rscl.getWorld().getName() + " at " + "x: " + rscl.getX() + " y: " + rscl.getY() + " z: " + rscl.getZ();
+                        }
+                    }
+                    break;
+                case "current_location_x":
+                    where.put("uuid", uuid);
+                    rst = new ResultSetTardis(plugin, where, "", false, 2);
+                    if (rst.resultSet()) {
+                        int id = rst.getTardis().getTardis_id();
+                        where.remove("uuid");
+                        where.put("tardis_id", id);
+                        ResultSetCurrentLocation rscl = new ResultSetCurrentLocation(plugin, where);
+                        if (rscl.resultSet()) {
+                            result = rscl.getX() + "";
+                        }
+                    }
+                    break;
+                case "current_location_y":
+                    where.put("uuid", uuid);
+                    rst = new ResultSetTardis(plugin, where, "", false, 2);
+                    if (rst.resultSet()) {
+                        int id = rst.getTardis().getTardis_id();
+                        where.remove("uuid");
+                        where.put("tardis_id", id);
+                        ResultSetCurrentLocation rscl = new ResultSetCurrentLocation(plugin, where);
+                        if (rscl.resultSet()) {
+                            result = rscl.getY() + "";
+                        }
+                    }
+                    break;
+                case "current_location_z":
+                    where.put("uuid", uuid);
+                    rst = new ResultSetTardis(plugin, where, "", false, 2);
+                    if (rst.resultSet()) {
+                        int id = rst.getTardis().getTardis_id();
+                        where.remove("uuid");
+                        where.put("tardis_id", id);
+                        ResultSetCurrentLocation rscl = new ResultSetCurrentLocation(plugin, where);
+                        if (rscl.resultSet()) {
+                            result = rscl.getZ() + "";
+                        }
+                    }
+                    break;
+                case "current_location_world":
+                    where.put("uuid", uuid);
+                    rst = new ResultSetTardis(plugin, where, "", false, 2);
+                    if (rst.resultSet()) {
+                        int id = rst.getTardis().getTardis_id();
+                        where.remove("uuid");
+                        where.put("tardis_id", id);
+                        ResultSetCurrentLocation rscl = new ResultSetCurrentLocation(plugin, where);
+                        if (rscl.resultSet()) {
+                            result = rscl.getWorld().getName() + "";
+                        }
+                    }
+                    break;
+                case "current_location_direction":
+                    where.put("uuid", uuid);
+                    rst = new ResultSetTardis(plugin, where, "", false, 2);
+                    if (rst.resultSet()) {
+                        int id = rst.getTardis().getTardis_id();
+                        where.remove("uuid");
+                        where.put("tardis_id", id);
+                        ResultSetCurrentLocation rscl = new ResultSetCurrentLocation(plugin, where);
+                        if (rscl.resultSet()) {
+                            result = rscl.getDirection() + "";
+                        }
+                    }
+                    break;
+                case "current_location_biome":
+                    where.put("uuid", uuid);
+                    rst = new ResultSetTardis(plugin, where, "", false, 2);
+                    if (rst.resultSet()) {
+                        int id = rst.getTardis().getTardis_id();
+                        where.remove("uuid");
+                        where.put("tardis_id", id);
+                        ResultSetCurrentLocation rscl = new ResultSetCurrentLocation(plugin, where);
+                        if (rscl.resultSet()) {
+                            result = rscl.getBiome() + "";
+                        }
                     }
                     break;
                 case "timelord_artron_amount":


### PR DESCRIPTION
This adds 7 PlaceholderAPI placeholders pertaining to the current location of the TARDIS.

Benefits over just using /tardis find:
Lets you see more (biome, direction, etc)
Lets you separate out x,y,z,world for use on scoreboard, GUIs, etc.

Messages in order of the screenshot below
Placeholder `%tardis_current_location_x%`
Placeholder `%tardis_current_location_y%`
Placeholder `%tardis_current_location_z%`
Placeholder `%tardis_current_location_world%`
Placeholder `%tardis_current_location_biome%`
Placeholder `%tardis_current_location_direction%`
Placeholder `%tardis_current_location%`
Command `/tardis find`

![example](https://cdn.discordapp.com/attachments/457230849277165610/696850957430161448/unknown.png)

Code's awful but I managed to get it working so I'm happy!