### PR TITLE
Add chunkgenerator to version output and move them to their own line

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -22,3 +22,6 @@ If applicable, add screenshots to help explain your problem.
 
 **Log files**
 If applicable, paste your server log (_showing the whole server startup to when the error occurs_) on a website like pastebin.com, and post a link here.
+
+**`/tardis version` output**
+Please include an output of your `/tardis version`.

--- a/src/main/java/me/eccentric_nz/TARDIS/commands/tardis/TARDISVersionCommand.java
+++ b/src/main/java/me/eccentric_nz/TARDIS/commands/tardis/TARDISVersionCommand.java
@@ -34,8 +34,12 @@ class TARDISVersionCommand {
 
     boolean displayVersion(CommandSender sender) {
         String version = plugin.getPM().getPlugin("TARDIS").getDescription().getVersion();
+        String chunkversion = plugin.getPM().getPlugin("TARDISChunkGenerator").getDescription().getVersion();
         String cb = Bukkit.getVersion();
-        sender.sendMessage(plugin.getPluginName() + "You are running TARDIS version: " + ChatColor.AQUA + version + ChatColor.RESET + " with CraftBukkit " + cb);
+        String bv = Bukkit.getBukkitVersion();
+        sender.sendMessage(plugin.getPluginName() + "TARDIS version: " + ChatColor.AQUA + version);// + ChatColor.RESET + " running " + implementation + cb);
+        sender.sendMessage(plugin.getPluginName() + "TARDISChunkGenerator version: " + ChatColor.AQUA + chunkversion);
+        sender.sendMessage(plugin.getPluginName() + "Server version: " + ChatColor.AQUA + bv + " " + cb);
         return true;
     }
 }


### PR DESCRIPTION
Example: 

![image](https://user-images.githubusercontent.com/8278263/79787028-f36b5d00-830b-11ea-8953-bb3ff6b8042e.png)

Can be more helpful if they include it in bug reports.
