### PR TITLE
Show plugin hook versions in /tardis version output

### DIFF
--- a/src/main/java/me/eccentric_nz/TARDIS/commands/tardis/TARDISVersionCommand.java
+++ b/src/main/java/me/eccentric_nz/TARDIS/commands/tardis/TARDISVersionCommand.java
@@ -50,11 +50,11 @@ class TARDISVersionCommand {
         sender.sendMessage(plugin.getPluginName() + "TARDISChunkGenerator version: " + ChatColor.AQUA + chunkversion);
 
         for (Plugin hook : pm.getPlugins()) {
-            final PluginDescriptionFile desc = hook.getDescription();
+            PluginDescriptionFile desc = hook.getDescription();
             String name = desc.getName();
             String version = desc.getVersion();
 
-            if(hooks.contains(name) && !name.equals("TARDISChunkGenerator")) {
+            if(hooks.contains(name)) {
                 sender.sendMessage(plugin.getPluginName() + name + " version: " + ChatColor.AQUA + version);
             }
         }

--- a/src/main/java/me/eccentric_nz/TARDIS/commands/tardis/TARDISVersionCommand.java
+++ b/src/main/java/me/eccentric_nz/TARDIS/commands/tardis/TARDISVersionCommand.java
@@ -39,15 +39,16 @@ class TARDISVersionCommand {
 
     boolean displayVersion(CommandSender sender) {
         final PluginManager pm = plugin.getPM();
+        String pluginName = plugin.getPluginName();
         List<String> hooks = plugin.getDescription().getSoftDepend();
-
-        String tardisversion = pm.getPlugin("TARDIS").getDescription().getVersion();
+        String tardisversion = plugin.getDescription().getVersion();
         String chunkversion = pm.getPlugin("TARDISChunkGenerator").getDescription().getVersion();
         String cb = Bukkit.getVersion();
         String bv = Bukkit.getBukkitVersion();
-        sender.sendMessage(plugin.getPluginName() + "Server version: " + ChatColor.AQUA + bv + " " + cb);
-        sender.sendMessage(plugin.getPluginName() + "TARDIS version: " + ChatColor.AQUA + tardisversion);
-        sender.sendMessage(plugin.getPluginName() + "TARDISChunkGenerator version: " + ChatColor.AQUA + chunkversion);
+        
+        sender.sendMessage(pluginName + "Server version: " + ChatColor.AQUA + bv + " " + cb);
+        sender.sendMessage(pluginName + "TARDIS version: " + ChatColor.AQUA + tardisversion);
+        sender.sendMessage(pluginName + "TARDISChunkGenerator version: " + ChatColor.AQUA + chunkversion);
 
         for (Plugin hook : pm.getPlugins()) {
             PluginDescriptionFile desc = hook.getDescription();
@@ -55,7 +56,7 @@ class TARDISVersionCommand {
             String version = desc.getVersion();
 
             if(hooks.contains(name)) {
-                sender.sendMessage(plugin.getPluginName() + name + " version: " + ChatColor.AQUA + version);
+                sender.sendMessage(pluginName + name + " version: " + ChatColor.AQUA + version);
             }
         }
 

--- a/src/main/java/me/eccentric_nz/TARDIS/commands/tardis/TARDISVersionCommand.java
+++ b/src/main/java/me/eccentric_nz/TARDIS/commands/tardis/TARDISVersionCommand.java
@@ -38,11 +38,11 @@ class TARDISVersionCommand {
     }
 
     boolean displayVersion(CommandSender sender) {
-        final PluginManager pm = Bukkit.getServer().getPluginManager();
+        final PluginManager pm = plugin.getPM();
         List<String> hooks = plugin.getDescription().getSoftDepend();
 
-        String tardisversion = plugin.getPM().getPlugin("TARDIS").getDescription().getVersion();
-        String chunkversion = plugin.getPM().getPlugin("TARDISChunkGenerator").getDescription().getVersion();
+        String tardisversion = pm.getPlugin("TARDIS").getDescription().getVersion();
+        String chunkversion = pm.getPlugin("TARDISChunkGenerator").getDescription().getVersion();
         String cb = Bukkit.getVersion();
         String bv = Bukkit.getBukkitVersion();
         sender.sendMessage(plugin.getPluginName() + "Server version: " + ChatColor.AQUA + bv + " " + cb);

--- a/src/main/java/me/eccentric_nz/TARDIS/commands/tardis/TARDISVersionCommand.java
+++ b/src/main/java/me/eccentric_nz/TARDIS/commands/tardis/TARDISVersionCommand.java
@@ -22,7 +22,6 @@ import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginDescriptionFile;
-import org.bukkit.plugin.PluginManager;
 
 import java.util.List;
 
@@ -38,19 +37,18 @@ class TARDISVersionCommand {
     }
 
     boolean displayVersion(CommandSender sender) {
-        final PluginManager pm = plugin.getPM();
         String pluginName = plugin.getPluginName();
         List<String> hooks = plugin.getDescription().getSoftDepend();
         String tardisversion = plugin.getDescription().getVersion();
-        String chunkversion = pm.getPlugin("TARDISChunkGenerator").getDescription().getVersion();
+        String chunkversion = plugin.getPM().getPlugin("TARDISChunkGenerator").getDescription().getVersion();
         String cb = Bukkit.getVersion();
         String bv = Bukkit.getBukkitVersion();
-        
+
         sender.sendMessage(pluginName + "Server version: " + ChatColor.AQUA + bv + " " + cb);
         sender.sendMessage(pluginName + "TARDIS version: " + ChatColor.AQUA + tardisversion);
         sender.sendMessage(pluginName + "TARDISChunkGenerator version: " + ChatColor.AQUA + chunkversion);
 
-        for (Plugin hook : pm.getPlugins()) {
+        for (Plugin hook : plugin.getPM().getPlugins()) {
             PluginDescriptionFile desc = hook.getDescription();
             String name = desc.getName();
             String version = desc.getVersion();

--- a/src/main/java/me/eccentric_nz/TARDIS/commands/tardis/TARDISVersionCommand.java
+++ b/src/main/java/me/eccentric_nz/TARDIS/commands/tardis/TARDISVersionCommand.java
@@ -20,6 +20,11 @@ import me.eccentric_nz.TARDIS.TARDIS;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.PluginDescriptionFile;
+import org.bukkit.plugin.PluginManager;
+
+import java.util.List;
 
 /**
  * @author eccentric_nz
@@ -33,13 +38,27 @@ class TARDISVersionCommand {
     }
 
     boolean displayVersion(CommandSender sender) {
-        String version = plugin.getPM().getPlugin("TARDIS").getDescription().getVersion();
+        final PluginManager pm = Bukkit.getServer().getPluginManager();
+        List<String> hooks = plugin.getDescription().getSoftDepend();
+
+        String tardisversion = plugin.getPM().getPlugin("TARDIS").getDescription().getVersion();
         String chunkversion = plugin.getPM().getPlugin("TARDISChunkGenerator").getDescription().getVersion();
         String cb = Bukkit.getVersion();
         String bv = Bukkit.getBukkitVersion();
-        sender.sendMessage(plugin.getPluginName() + "TARDIS version: " + ChatColor.AQUA + version);// + ChatColor.RESET + " running " + implementation + cb);
-        sender.sendMessage(plugin.getPluginName() + "TARDISChunkGenerator version: " + ChatColor.AQUA + chunkversion);
         sender.sendMessage(plugin.getPluginName() + "Server version: " + ChatColor.AQUA + bv + " " + cb);
+        sender.sendMessage(plugin.getPluginName() + "TARDIS version: " + ChatColor.AQUA + tardisversion);
+        sender.sendMessage(plugin.getPluginName() + "TARDISChunkGenerator version: " + ChatColor.AQUA + chunkversion);
+
+        for (Plugin hook : pm.getPlugins()) {
+            final PluginDescriptionFile desc = hook.getDescription();
+            String name = desc.getName();
+            String version = desc.getVersion();
+
+            if(hooks.contains(name) && !name.equals("TARDISChunkGenerator")) {
+                sender.sendMessage(plugin.getPluginName() + name + " version: " + ChatColor.AQUA + version);
+            }
+        }
+
         return true;
     }
 }


### PR DESCRIPTION
Now is more like /essentials version output. Shows any plugins listed as a "softdepend" and their versions.

Essentials output on top
![image](https://user-images.githubusercontent.com/8278263/81643920-4c4e8280-93ec-11ea-8cb3-b5b2001197d6.png)
TARDIS output on bottom