### PR TITLE
Show "x builds behind" if op in /tardis version output

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         </repository>
         <repository>
             <id>placeholderapi</id>
-            <url>http://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+            <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
         </repository>
         <repository>
             <id>papermc</id>

--- a/src/main/java/me/eccentric_nz/TARDIS/commands/tardis/TARDISVersionCommand.java
+++ b/src/main/java/me/eccentric_nz/TARDIS/commands/tardis/TARDISVersionCommand.java
@@ -17,7 +17,6 @@
 package me.eccentric_nz.TARDIS.commands.tardis;
 
 import me.eccentric_nz.TARDIS.TARDIS;
-import me.eccentric_nz.TARDIS.utility.TARDISUpdateChecker;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
@@ -58,16 +57,17 @@ class TARDISVersionCommand {
         }
         if(sender.isOp()) {
             sender.sendMessage(pluginName + "Checking for new TARDIS builds...");
-            int[] buildNumbers = new TARDISUpdateChecker(plugin).getBuildNumbers();
-            if (buildNumbers[1] == 0) {
+            int build = plugin.getBuildNumber();
+            int latest = plugin.getUpdateNumber();
+            if (build == 0) {
                 sender.sendMessage(pluginName + "Unable to check for new builds!");
                 return true;
             }
-            if (buildNumbers[0] == buildNumbers[1]) {
+            if (build == latest) {
                 sender.sendMessage(pluginName + "You are running the latest version!");
             } else {
                 sender.sendMessage(pluginName +
-                        "You are " + (buildNumbers[1] - buildNumbers[0]) + " builds behind! Type " + ChatColor.AQUA +
+                        "You are " + (latest - build) + " builds behind! Type " + ChatColor.AQUA +
                         "/tadmin update_plugins" + ChatColor.RESET + " to update!"
                 );
             }

--- a/src/main/java/me/eccentric_nz/TARDIS/commands/tardis/TARDISVersionCommand.java
+++ b/src/main/java/me/eccentric_nz/TARDIS/commands/tardis/TARDISVersionCommand.java
@@ -17,6 +17,7 @@
 package me.eccentric_nz.TARDIS.commands.tardis;
 
 import me.eccentric_nz.TARDIS.TARDIS;
+import me.eccentric_nz.TARDIS.utility.TARDISUpdateChecker;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
@@ -42,9 +43,8 @@ class TARDISVersionCommand {
         String tardisversion = plugin.getDescription().getVersion();
         String chunkversion = plugin.getPM().getPlugin("TARDISChunkGenerator").getDescription().getVersion();
         String cb = Bukkit.getVersion();
-        String bv = Bukkit.getBukkitVersion();
         // send server and TARDIS versions
-        sender.sendMessage(pluginName + "Server version: " + ChatColor.AQUA + bv + " " + cb);
+        sender.sendMessage(pluginName + "Server version: " + ChatColor.AQUA + cb);
         sender.sendMessage(pluginName + "TARDIS version: " + ChatColor.AQUA + tardisversion);
         sender.sendMessage(pluginName + "TARDISChunkGenerator version: " + ChatColor.AQUA + chunkversion);
         // send dependent plugin versions
@@ -54,6 +54,22 @@ class TARDISVersionCommand {
             String version = desc.getVersion();
             if (hooks.contains(name)) {
                 sender.sendMessage(pluginName + name + " version: " + ChatColor.AQUA + version);
+            }
+        }
+        if(sender.isOp()) {
+            sender.sendMessage(pluginName + "Checking for new TARDIS builds...");
+            int[] buildNumbers = new TARDISUpdateChecker(plugin).getBuildNumbers();
+            if (buildNumbers[1] == 0) {
+                sender.sendMessage(pluginName + "Unable to check for new builds!");
+                return true;
+            }
+            if (buildNumbers[0] == buildNumbers[1]) {
+                sender.sendMessage(pluginName + "You are running the latest version!");
+            } else {
+                sender.sendMessage(pluginName +
+                        "You are " + (buildNumbers[1] - buildNumbers[0]) + " builds behind! Type " + ChatColor.AQUA +
+                        "/tadmin update_plugins" + ChatColor.RESET + " to update!"
+                );
             }
         }
         return true;

--- a/src/main/java/me/eccentric_nz/TARDIS/utility/TARDISUpdateChecker.java
+++ b/src/main/java/me/eccentric_nz/TARDIS/utility/TARDISUpdateChecker.java
@@ -32,9 +32,6 @@ public class TARDISUpdateChecker implements Runnable {
     private final TARDIS plugin;
     private final JsonParser jp;
 
-    private static int buildNumber = 0;
-    private static int newBuildNumber = 0;
-
     public TARDISUpdateChecker(TARDIS plugin) {
         this.plugin = plugin;
         jp = new JsonParser();
@@ -51,13 +48,13 @@ public class TARDISUpdateChecker implements Runnable {
             // local build, not a Jenkins build
             return;
         }
-        buildNumber = Integer.parseInt(build);
+        int buildNumber = Integer.parseInt(build);
         JsonObject lastBuild = fetchLatestJenkinsBuild();
         if (lastBuild == null || !lastBuild.has("id")) {
             // couldn't get Jenkins info
             return;
         }
-        newBuildNumber = lastBuild.get("id").getAsInt();
+        int newBuildNumber = lastBuild.get("id").getAsInt();
         if (newBuildNumber <= buildNumber) {
             // if new build number is same or older
             return;
@@ -67,12 +64,6 @@ public class TARDISUpdateChecker implements Runnable {
         plugin.setUpdateNumber(newBuildNumber);
         plugin.getConsole().sendMessage(plugin.getPluginName() + String.format(TARDISMessage.JENKINS_UPDATE_READY, buildNumber, newBuildNumber));
         plugin.getConsole().sendMessage(plugin.getPluginName() + TARDISMessage.UPDATE_COMMAND);
-    }
-
-    public int[] getBuildNumbers() {
-        if(newBuildNumber == 0)
-            run();
-        return new int[]{buildNumber, newBuildNumber};
     }
 
     /**


### PR DESCRIPTION
It's ya girl back at it with another /tardis version change

This time, mimicking /icanhasbukkit, it will show you how many builds behind you are, if any.

If behind:
![image](https://user-images.githubusercontent.com/8278263/88595381-72b5ae80-d028-11ea-8ae2-aa67e743d469.png)

If up to date:
![image](https://user-images.githubusercontent.com/8278263/88595412-7fd29d80-d028-11ea-9a64-30b15aecf067.png)

Also, I removed the "1.16.1-R0.1-SNAPSHOT" stuff as this just an API version and is not necessary for a proper response.

Also x2, I added a user agent header to the update checking. When I implemented a checker in my plugin I found a lack of user agent makes Jenkins mad.

Also x3, I slipped in a http -> https for the PAPI repo.
