### PR TITLE
Stop assigning eccentricdevotion on new issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,6 @@ name: Bug report
 about: Report a TARDIS error
 title: ''
 labels: bug
-assignees: eccentricdevotion
 
 ---
 


### PR DESCRIPTION
We can't assign people, this was happening automatically :)
https://github.com/eccentricdevotion/TARDIS/discussions/408