### PR TITLE
Handle missing biome column in ResultSetCurrent

### DIFF
--- a/src/main/java/me/eccentric_nz/TARDIS/database/resultset/ResultSetCurrentLocation.java
+++ b/src/main/java/me/eccentric_nz/TARDIS/database/resultset/ResultSetCurrentLocation.java
@@ -117,8 +117,11 @@ public class ResultSetCurrentLocation {
                         } else {
                             biomeKey = new NamespacedKey(split[0], split[1]);
                         }
-                    } else {
+                    } else if (!key.isBlank()) {
                         biomeKey = NamespacedKey.minecraft(key.toLowerCase(Locale.ROOT));
+                    } else {
+                        // biome column can be null now that we're not tracking police box biome
+                        biomeKey = null;
                     }
                 }
             } else {


### PR DESCRIPTION
This fixes an error when interacting with newly created TARDISes, since the biome column in the current location table of the database is left empty. With a null/empty biome column, ResultSetCurrent throws an error like the one below when trying to interact with the TARDIS at all.

```
[20:26:45 ERROR]: Could not pass event PlayerInteractEvent to TARDIS v4.6.3-b2288
java.lang.IllegalArgumentException: Invalid key. Must be [a-z0-9/._-]: 
        at com.google.common.base.Preconditions.checkArgument(Preconditions.java:191) ~[patched_1.16.5.jar:git-Paper-752]
        at org.bukkit.NamespacedKey.<init>(NamespacedKey.java:50) ~[patched_1.16.5.jar:git-Paper-752]
        at org.bukkit.NamespacedKey.minecraft(NamespacedKey.java:143) ~[patched_1.16.5.jar:git-Paper-752]
        at me.eccentric_nz.TARDIS.database.resultset.ResultSetCurrentLocation.resultSet(ResultSetCurrentLocation.java:121) ~[?:?]
        at me.eccentric_nz.TARDIS.move.TARDISAnyoneDoorListener.onDoorInteract(TARDISAnyoneDoorListener.java:316) ~[?:?]
        at com.destroystokyo.paper.event.executor.asm.generated.GeneratedEventExecutor337.execute(Unknown Source) ~[?:?]
        at org.bukkit.plugin.EventExecutor.lambda$create$1(EventExecutor.java:69) ~[patched_1.16.5.jar:git-Paper-752]
        at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[patched_1.16.5.jar:git-Paper-752]
        at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[patched_1.16.5.jar:git-Paper-752]
        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:624) ~[patched_1.16.5.jar:git-Paper-752]
        at org.bukkit.craftbukkit.v1_16_R3.event.CraftEventFactory.callPlayerInteractEvent(CraftEventFactory.java:549) ~[patched_1.16.5.jar:git-Paper-752]
        at net.minecraft.server.v1_16_R3.PlayerInteractManager.a(PlayerInteractManager.java:499) ~[patched_1.16.5.jar:git-Paper-752]
        at net.minecraft.server.v1_16_R3.PlayerConnection.a(PlayerConnection.java:1714) ~[patched_1.16.5.jar:git-Paper-752]
        at net.minecraft.server.v1_16_R3.PacketPlayInUseItem.a(PacketPlayInUseItem.java:32) ~[patched_1.16.5.jar:git-Paper-752]
        at net.minecraft.server.v1_16_R3.PacketPlayInUseItem.a(PacketPlayInUseItem.java:10) ~[patched_1.16.5.jar:git-Paper-752]
        at net.minecraft.server.v1_16_R3.PlayerConnectionUtils.lambda$ensureMainThread$1(PlayerConnectionUtils.java:35) ~[patched_1.16.5.jar:git-Paper-752]
        at net.minecraft.server.v1_16_R3.TickTask.run(SourceFile:18) ~[patched_1.16.5.jar:git-Paper-752]
        at net.minecraft.server.v1_16_R3.IAsyncTaskHandler.executeTask(IAsyncTaskHandler.java:136) ~[patched_1.16.5.jar:git-Paper-752]
        at net.minecraft.server.v1_16_R3.IAsyncTaskHandlerReentrant.executeTask(SourceFile:23) ~[patched_1.16.5.jar:git-Paper-752]
        at net.minecraft.server.v1_16_R3.IAsyncTaskHandler.executeNext(IAsyncTaskHandler.java:109) ~[patched_1.16.5.jar:git-Paper-752]
        at net.minecraft.server.v1_16_R3.MinecraftServer.bb(MinecraftServer.java:1266) ~[patched_1.16.5.jar:git-Paper-752]
        at net.minecraft.server.v1_16_R3.MinecraftServer.executeNext(MinecraftServer.java:1259) ~[patched_1.16.5.jar:git-Paper-752]
        at net.minecraft.server.v1_16_R3.IAsyncTaskHandler.executeAll(IAsyncTaskHandler.java:95) ~[patched_1.16.5.jar:git-Paper-752]
        at net.minecraft.server.v1_16_R3.MinecraftServer.a(MinecraftServer.java:1395) ~[patched_1.16.5.jar:git-Paper-752]
        at net.minecraft.server.v1_16_R3.MinecraftServer.w(MinecraftServer.java:1130) ~[patched_1.16.5.jar:git-Paper-752]
        at net.minecraft.server.v1_16_R3.MinecraftServer.lambda$a$0(MinecraftServer.java:291) ~[patched_1.16.5.jar:git-Paper-752]
        at java.lang.Thread.run(Thread.java:831) [?:?]
```