### PR TITLE
fix: Set up blockLogger before using it in TARDISVortexPersister

### DIFF
--- a/src/main/java/me/eccentric_nz/TARDIS/TARDIS.java
+++ b/src/main/java/me/eccentric_nz/TARDIS/TARDIS.java
@@ -480,6 +480,11 @@ public class TARDIS extends JavaPlugin {
             if (getConfig().getInt("allow.force_field") > 0) {
                 getServer().getScheduler().scheduleSyncRepeatingTask(this, new TARDISForceField(this), 20, 5);
             }
+            // hook CoreProtectAPI
+            if (pm.getPlugin("CoreProtect") != null) {
+                debug("Logging block changes with CoreProtect.");
+                blockLogger.enableLogger();
+            }
             new TARDISVortexPersister(this).load();
             new TARDISJunkPlayerPersister(this).load();
             new TARDISSeedBlockPersister(this).load();
@@ -526,11 +531,6 @@ public class TARDIS extends JavaPlugin {
                 new TARDISPlaceholderExpansion(this).register();
             }
             blockLogger = new TARDISBlockLogger(this);
-            // hook CoreProtectAPI
-            if (pm.getPlugin("CoreProtect") != null) {
-                debug("Logging block changes with CoreProtect.");
-                blockLogger.enableLogger();
-            }
             if (!getConfig().getBoolean("conversions.restore_biomes")) {
                 getServer().getScheduler().scheduleSyncDelayedTask(this, () -> {
                     new TARDISBiomeConverter(this).convertBiomes();


### PR DESCRIPTION
Fixes a concurrency error where TARDISVortexPersister.load() starts scheduled tasks that can sometimes reference TARDIS.getBlockLogger() before it is initialized.

Stacktrace of error:
```
[18:27:27] [Server thread/ERROR]: Error occurred while enabling TARDIS v4.6.3-b2283 (Is it up to date?)
java.lang.NullPointerException: null
	at me.eccentric_nz.TARDIS.utility.TARDISBlockSetters.setBlock(TARDISBlockSetters.java:107) ~[?:?]
	at me.eccentric_nz.TARDIS.builders.TARDISInstantPreset.buildPreset(TARDISInstantPreset.java:355) ~[?:?]
	at me.eccentric_nz.TARDIS.flight.TARDISVortexPersister.load(TARDISVortexPersister.java:156) ~[?:?]
	at me.eccentric_nz.TARDIS.TARDIS.onEnable(TARDIS.java:486) ~[?:?]
```

This is the part that sometimes tries to reference the blockLogger before it is defined:
https://github.com/eccentricdevotion/TARDIS/blob/323358c3668b39f163ea014196d51b1ad460ba76/src/main/java/me/eccentric_nz/TARDIS/utility/TARDISBlockSetters.java#L147-L149