### PR TITLE
[URGENT] Fix the bug I created last night trying to fix the block logger concurrency error

### DIFF
--- a/src/main/java/me/eccentric_nz/TARDIS/TARDIS.java
+++ b/src/main/java/me/eccentric_nz/TARDIS/TARDIS.java
@@ -481,6 +481,7 @@ public class TARDIS extends JavaPlugin {
                 getServer().getScheduler().scheduleSyncRepeatingTask(this, new TARDISForceField(this), 20, 5);
             }
             // hook CoreProtectAPI
+            blockLogger = new TARDISBlockLogger(this);
             if (pm.getPlugin("CoreProtect") != null) {
                 debug("Logging block changes with CoreProtect.");
                 blockLogger.enableLogger();
@@ -530,7 +531,6 @@ public class TARDIS extends JavaPlugin {
                 debug("Registering expansion with PlaceholderAPI.");
                 new TARDISPlaceholderExpansion(this).register();
             }
-            blockLogger = new TARDISBlockLogger(this);
             if (!getConfig().getBoolean("conversions.restore_biomes")) {
                 getServer().getScheduler().scheduleSyncDelayedTask(this, () -> {
                     new TARDISBiomeConverter(this).convertBiomes();


### PR DESCRIPTION
It looks like I missed a line of code last night fixing the block logger concurrency error, it looks like in that version if you have CoreProtect installed the plugin fails to load. This fixes that issue, I'm so sorry for not testing it on a server with CoreProtect first!