### PR TITLE
Add period character to player name validator

### DIFF
--- a/src/main/java/me/eccentric_nz/TARDIS/TARDIS.java
+++ b/src/main/java/me/eccentric_nz/TARDIS/TARDIS.java
@@ -481,6 +481,7 @@ public class TARDIS extends JavaPlugin {
                 getServer().getScheduler().scheduleSyncRepeatingTask(this, new TARDISForceField(this), 20, 5);
             }
             // hook CoreProtectAPI
+            blockLogger = new TARDISBlockLogger(this);
             if (pm.getPlugin("CoreProtect") != null) {
                 debug("Logging block changes with CoreProtect.");
                 blockLogger.enableLogger();
@@ -530,7 +531,6 @@ public class TARDIS extends JavaPlugin {
                 debug("Registering expansion with PlaceholderAPI.");
                 new TARDISPlaceholderExpansion(this).register();
             }
-            blockLogger = new TARDISBlockLogger(this);
             if (!getConfig().getBoolean("conversions.restore_biomes")) {
                 getServer().getScheduler().scheduleSyncDelayedTask(this, () -> {
                     new TARDISBiomeConverter(this).convertBiomes();

--- a/src/main/java/me/eccentric_nz/TARDIS/advanced/TARDISDiskWriterCommand.java
+++ b/src/main/java/me/eccentric_nz/TARDIS/advanced/TARDISDiskWriterCommand.java
@@ -198,7 +198,7 @@ public class TARDISDiskWriterCommand {
                     TARDISMessage.send(player, "TOO_FEW_ARGS");
                     return false;
                 }
-                if (!args[1].matches("[A-Za-z0-9_*]{2,16}")) {
+                if (!args[1].matches("[A-Za-z0-9_*.]{2,16}")) {
                     TARDISMessage.send(player, "PLAYER_NOT_VALID");
                     return false;
                 }

--- a/src/main/java/me/eccentric_nz/TARDIS/commands/tardis/TARDISAddCompanionCommand.java
+++ b/src/main/java/me/eccentric_nz/TARDIS/commands/tardis/TARDISAddCompanionCommand.java
@@ -81,7 +81,7 @@ class TARDISAddCompanionCommand {
                 TARDISMessage.send(player, "TOO_FEW_ARGS");
                 return false;
             }
-            if (!args[1].matches("[A-Za-z0-9_*]{2,16}")) {
+            if (!args[1].matches("[A-Za-z0-9_*.]{2,16}")) {
                 TARDISMessage.send(player, "PLAYER_NOT_VALID");
             } else {
                 boolean addAll = (args[1].equalsIgnoreCase("everyone") || args[1].equalsIgnoreCase("all"));

--- a/src/main/java/me/eccentric_nz/TARDIS/commands/tardis/TARDISRemoveCompanionCommand.java
+++ b/src/main/java/me/eccentric_nz/TARDIS/commands/tardis/TARDISRemoveCompanionCommand.java
@@ -67,7 +67,7 @@ class TARDISRemoveCompanionCommand {
                 TARDISMessage.send(player, "TOO_FEW_ARGS");
                 return false;
             }
-            if (!args[1].matches("[A-Za-z0-9_*]{2,16}")) {
+            if (!args[1].matches("[A-Za-z0-9_*.]{2,16}")) {
                 TARDISMessage.send(player, "PLAYER_NOT_VALID");
             } else {
                 String newList = "";


### PR DESCRIPTION
With Geyser's [Floodgate 2.0](https://github.com/GeyserMC/Floodgate/), the default prefix for Bedrock players' usernames is a period. This commit adds support for mentioning those players with commands, as currently you can't `/tardis add` Bedrock players, etc.