### PR TITLE
Add period to list of valid characters for usernames

### DIFF
--- a/src/main/java/me/eccentric_nz/TARDIS/advanced/TARDISDiskWriterCommand.java
+++ b/src/main/java/me/eccentric_nz/TARDIS/advanced/TARDISDiskWriterCommand.java
@@ -198,7 +198,7 @@ public class TARDISDiskWriterCommand {
                     TARDISMessage.send(player, "TOO_FEW_ARGS");
                     return false;
                 }
-                if (!args[1].matches("[A-Za-z0-9_*]{2,16}")) {
+                if (!args[1].matches("[A-Za-z0-9_*.]{2,16}")) {
                     TARDISMessage.send(player, "PLAYER_NOT_VALID");
                     return false;
                 }

--- a/src/main/java/me/eccentric_nz/TARDIS/commands/tardis/TARDISAddCompanionCommand.java
+++ b/src/main/java/me/eccentric_nz/TARDIS/commands/tardis/TARDISAddCompanionCommand.java
@@ -81,7 +81,7 @@ class TARDISAddCompanionCommand {
                 TARDISMessage.send(player, "TOO_FEW_ARGS");
                 return false;
             }
-            if (!args[1].matches("[A-Za-z0-9_*]{2,16}")) {
+            if (!args[1].matches("[A-Za-z0-9_*.]{2,16}")) {
                 TARDISMessage.send(player, "PLAYER_NOT_VALID");
             } else {
                 boolean addAll = (args[1].equalsIgnoreCase("everyone") || args[1].equalsIgnoreCase("all"));

--- a/src/main/java/me/eccentric_nz/TARDIS/commands/tardis/TARDISRemoveCompanionCommand.java
+++ b/src/main/java/me/eccentric_nz/TARDIS/commands/tardis/TARDISRemoveCompanionCommand.java
@@ -67,7 +67,7 @@ class TARDISRemoveCompanionCommand {
                 TARDISMessage.send(player, "TOO_FEW_ARGS");
                 return false;
             }
-            if (!args[1].matches("[A-Za-z0-9_*]{2,16}")) {
+            if (!args[1].matches("[A-Za-z0-9_*.]{2,16}")) {
                 TARDISMessage.send(player, "PLAYER_NOT_VALID");
             } else {
                 String newList = "";


### PR DESCRIPTION
With Geyser's [Floodgate 2.0](https://github.com/GeyserMC/Floodgate/), the default prefix for Bedrock players' usernames is a period. This commit adds support for mentioning those players with commands, as currently you can't `/tardis add` Bedrock players, etc.