### PR TITLE
fix: Handle clicking outside save sign inventory

### DIFF
--- a/src/main/java/me/eccentric_nz/TARDIS/listeners/TARDISSaveSignListener.java
+++ b/src/main/java/me/eccentric_nz/TARDIS/listeners/TARDISSaveSignListener.java
@@ -69,6 +69,9 @@ public class TARDISSaveSignListener extends TARDISMenuListener implements Listen
      */
     @EventHandler(ignoreCancelled = true)
     public void onSaveTerminalClick(InventoryClickEvent event) {
+        // player clicked outside inventory
+        if (event.getClickedInventory() == null) return;
+        
         InventoryView view = event.getView();
         String name = view.getTitle();
         if (name.startsWith(ChatColor.DARK_RED + "TARDIS saves")) {


### PR DESCRIPTION
Fixes #529 

Handles clicking outside a save sign menu inventory.