### PR TITLE
Fix handles duplication glitch

### DIFF
--- a/src/main/java/me/eccentric_nz/TARDIS/listeners/TARDISItemFrameListener.java
+++ b/src/main/java/me/eccentric_nz/TARDIS/listeners/TARDISItemFrameListener.java
@@ -365,7 +365,6 @@ public class TARDISItemFrameListener implements Listener {
                 if (player != null) {
                     if (player.isSneaking()) {
                         talkingHandles.add(handlesId);    // add this handles to the list of currently talking handleses (by tardis id)
-                        plugin.debug(String.format("Adding handles ID %d to talking handles list", handlesId));
                         
                         event.setCancelled(true);
                         TARDISSounds.playTARDISSound(player, "handles", 5L);
@@ -375,7 +374,6 @@ public class TARDISItemFrameListener implements Listener {
                         frame.setItem(is, false);
                         plugin.getServer().getScheduler().scheduleSyncDelayedTask(plugin, () -> {
                             talkingHandles.remove(handlesId);   // remove this handles from the list of talking handles
-                            plugin.debug(String.format("Removing handles ID %d from talking handles list", handlesId));
                             
                             im.setCustomModelData(10000001);
                             is.setItemMeta(im);

--- a/src/main/java/me/eccentric_nz/TARDIS/listeners/TARDISItemFrameListener.java
+++ b/src/main/java/me/eccentric_nz/TARDIS/listeners/TARDISItemFrameListener.java
@@ -387,7 +387,8 @@ public class TARDISItemFrameListener implements Listener {
                         }, 40L);
                     } else {
                         // is the handles currently talking?
-                        if (talkingHandles.stream().anyMatch(id -> id.equals(handlesId))) { // match by predicate since handlesId was fetched from database again
+                        // match by predicate in case multiple entries are in list. can happen when handles is clicked many times repeatedly
+                        if (talkingHandles.stream().anyMatch(id -> id.equals(handlesId))) {
                             event.setCancelled(true);
                             plugin.debug(String.format("Cancelling breaking handles ID %d because he is still talking", handlesId));
                             return;

--- a/src/main/java/me/eccentric_nz/TARDIS/listeners/TARDISItemFrameListener.java
+++ b/src/main/java/me/eccentric_nz/TARDIS/listeners/TARDISItemFrameListener.java
@@ -43,6 +43,8 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -51,9 +53,11 @@ import java.util.UUID;
 public class TARDISItemFrameListener implements Listener {
 
     private final TARDIS plugin;
-
+    private final List<Integer> talkingHandles = new ArrayList<Integer>();
+    
     public TARDISItemFrameListener(TARDIS plugin) {
         this.plugin = plugin;
+        
     }
 
     @EventHandler(ignoreCancelled = true)
@@ -354,8 +358,15 @@ public class TARDISItemFrameListener implements Listener {
                 if (!rsc.resultSet()) {
                     return;
                 }
+                
+                // set this handles id to its tardis id
+                Integer handlesId = rsc.getTardis_id();
+                
                 if (player != null) {
                     if (player.isSneaking()) {
+                        talkingHandles.add(handlesId);    // add this handles to the list of currently talking handleses (by tardis id)
+                        plugin.debug(String.format("Adding handles ID %d to talking handles list", handlesId));
+                        
                         event.setCancelled(true);
                         TARDISSounds.playTARDISSound(player, "handles", 5L);
                         ItemMeta im = is.getItemMeta();
@@ -363,11 +374,21 @@ public class TARDISItemFrameListener implements Listener {
                         is.setItemMeta(im);
                         frame.setItem(is, false);
                         plugin.getServer().getScheduler().scheduleSyncDelayedTask(plugin, () -> {
+                            talkingHandles.remove(handlesId);   // remove this handles from the list of talking handles
+                            plugin.debug(String.format("Removing handles ID %d from talking handles list", handlesId));
+                            
                             im.setCustomModelData(10000001);
                             is.setItemMeta(im);
                             frame.setItem(is, false);
                         }, 40L);
                     } else {
+                        // is the handles currently talking?
+                        if (talkingHandles.stream().anyMatch(id -> id.equals(handlesId))) { // match by predicate since handlesId was fetched from database again
+                            event.setCancelled(true);
+                            plugin.debug(String.format("Cancelling breaking handles ID %d because he is still talking", handlesId));
+                            return;
+                        }
+                        
                         // is it the players handles?
                         ResultSetTardisID rst = new ResultSetTardisID(plugin);
                         if (rst.fromUUID(player.getUniqueId().toString()) && rsc.getTardis_id() == rst.getTardis_id()) {

--- a/src/main/java/me/eccentric_nz/TARDIS/listeners/TARDISItemFrameListener.java
+++ b/src/main/java/me/eccentric_nz/TARDIS/listeners/TARDISItemFrameListener.java
@@ -257,13 +257,19 @@ public class TARDISItemFrameListener implements Listener {
                 }
                 ItemStack is = frame.getItem();
                 if (isHandles(is)) {
+                    Integer handlesId = rsh.getTardis_id();
+                    
                     // play sound
+                    talkingHandles.add(handlesId);    // add this handles to the list of currently talking handleses (by tardis id)
                     TARDISSounds.playTARDISSound(player, "handles", 5L);
+                    
                     ItemMeta im = is.getItemMeta();
                     im.setCustomModelData(10000002);
                     is.setItemMeta(im);
                     frame.setItem(is, false);
                     plugin.getServer().getScheduler().scheduleSyncDelayedTask(plugin, () -> {
+                        talkingHandles.remove(handlesId);   // remove this handles from the list of talking handles
+                        
                         im.setCustomModelData(10000001);
                         is.setItemMeta(im);
                         frame.setItem(is, false);


### PR DESCRIPTION
If you break handles while he is talking it drops a "talking" handles, then the plugin replaces him with a non-talking handles after 40 ticks. This effectively creates 2 handles and be can replicated forever. This PR fixes the duplication glitch by keeping track of currently talking handles and prevents the player from breaking him until he's done talking.