### PR TITLE
fix: Use player respawn location in respawn listener

### DIFF
--- a/src/main/java/me/eccentric_nz/TARDIS/arch/TARDISRespawnListener.java
+++ b/src/main/java/me/eccentric_nz/TARDIS/arch/TARDISRespawnListener.java
@@ -44,9 +44,10 @@ public class TARDISRespawnListener implements Listener {
         UUID uuid = player.getUniqueId();
         // check if we should re-arch this player
         plugin.getServer().getScheduler().scheduleSyncDelayedTask(plugin, () -> new TARDISArchPersister(plugin).reArch(uuid), 5L);
-        if (!plugin.getUtils().inTARDISWorld(player)) {
+        if (!plugin.getUtils().inTARDISWorld(event.getRespawnLocation())) {
             // reset player time
             player.resetPlayerTime();
+
             // remove the player from the travellers table if they respawned in a non-TARDIS world
             HashMap<String, Object> where = new HashMap<>();
             where.put("uuid", uuid.toString());


### PR DESCRIPTION
In the player respawn listener, the player's _current_ location is being used to check which world they're in. This location is their death location, so if players die in a TARDIS world they won't have their time reset and won't be removed from the travellers table.

This PR changes the respawn handler to use their respawn location instead, which ensures the player time is reset and that the player is removed from the travellers table successfully. 