### PR TITLE
fix: Always allow region entry with open door policy

### DIFF
--- a/src/main/java/me/eccentric_nz/TARDIS/commands/tardis/TARDISRemoveCompanionCommand.java
+++ b/src/main/java/me/eccentric_nz/TARDIS/commands/tardis/TARDISRemoveCompanionCommand.java
@@ -111,10 +111,8 @@ class TARDISRemoveCompanionCommand {
                         if (w != null) {
                             if (args[1].equals("all")) {
                                 plugin.getWorldGuardUtils().removeAllMembersFromRegion(w, owner, player.getUniqueId());
-                                if (!plugin.getConfig().getBoolean("preferences.open_door_policy")) {
-                                    // set entry and exit flags to deny
-                                    plugin.getWorldGuardUtils().setEntryExitFlags(w.getName(), player.getName(), false);
-                                }
+                                // set entry and exit flags to deny
+                                plugin.getWorldGuardUtils().setEntryExitFlags(w.getName(), player.getName(), false);
                             }
                         }
                     }

--- a/src/main/java/me/eccentric_nz/TARDIS/utility/TARDISWorldGuardUtils.java
+++ b/src/main/java/me/eccentric_nz/TARDIS/utility/TARDISWorldGuardUtils.java
@@ -737,10 +737,14 @@ public class TARDISWorldGuardUtils {
                     region = rm.getRegion("TARDIS_" + sanitised);
                 }
             }
+
+            // always allow region entry if open door policy is true
+            State flag = (allow || plugin.getConfig().getBoolean("preferences.open_door_policy")) ? State.ALLOW : State.DENY;
+
             if (region != null) {
                 Map<Flag<?>, Object> flags = region.getFlags();
-                flags.put(Flags.ENTRY, (allow) ? State.ALLOW : State.DENY);
-                flags.put(Flags.EXIT, (allow) ? State.ALLOW : State.DENY);
+                flags.put(Flags.ENTRY, flag);
+                flags.put(Flags.EXIT, flag);
                 region.setFlags(flags);
                 try {
                     rm.save();


### PR DESCRIPTION
In aae7f52c527b1966dd6380201df62f5d571c6f5d the bug regarding `open_door_policy` was fixed for removing all companions, but it would still occur when adding new companions, or really doing anything that calls `TARDISWorldGuardUtils#setEntryExitFlags`. 

This commit fixes the issue in all cases.

Fixes #537 