### PR TITLE
Fix worldCheck on normal 1.18 worlds

### DIFF
--- a/src/main/java/me/eccentric_nz/TARDIS/travel/TARDISCaveFinder.java
+++ b/src/main/java/me/eccentric_nz/TARDIS/travel/TARDISCaveFinder.java
@@ -178,9 +178,9 @@ public class TARDISCaveFinder {
     private boolean worldCheck(World w) {
         Location spawn = w.getSpawnLocation();
         int y = w.getHighestBlockYAt(spawn);
-        if (y < 15) {
+        if (y < -49) {
             return false;
-        } else if (w.getBlockAt(spawn.getBlockX(), 0, spawn.getBlockZ()).getType().isAir()) {
+        } else if (w.getBlockAt(spawn.getBlockX(), -64, spawn.getBlockZ()).getType().isAir()) {
             return false;
         } else {
             // move 20 blocks north


### PR DESCRIPTION
So worlds are shorter now...

They can technically go to -2048, but that's a whole other can of worms.

If this is just checking super flat, do we not have any better ways of checking this?



Funny way I used to check this, I placed a block at 0,0,0 (spawn was X:0, Z:0), and the cave check started working.