### PR TITLE
Add a way to negate specific /tardisprefs sub-commands

### DIFF
--- a/src/main/java/me/eccentric_nz/TARDIS/blueprints/TARDISPermission.java
+++ b/src/main/java/me/eccentric_nz/TARDIS/blueprints/TARDISPermission.java
@@ -58,6 +58,19 @@ public class TARDISPermission {
         }
     }
 
+    /**
+     * Checks to see if a player has this permission node SET to FALSE.
+     * If the player simply does not have this permission (unset), this will return FALSE.
+     * This will only return true if the player has the node, and it's negated.
+     *
+     * @param player the player to check
+     * @param node  the node to check
+     * @return true if the player has the node, and it's negated
+     */
+    public static boolean isNegated(Player player, String node) {
+        return player.isPermissionSet(node) && !player.hasPermission(node);
+    }
+
     private static boolean hasBlueprintPermission(String uuid, String node) {
         return new ResultSetBlueprint(TARDIS.plugin).getPerm(uuid, node);
     }

--- a/src/main/java/me/eccentric_nz/TARDIS/commands/preferences/TARDISPrefsCommands.java
+++ b/src/main/java/me/eccentric_nz/TARDIS/commands/preferences/TARDISPrefsCommands.java
@@ -16,6 +16,7 @@
  */
 package me.eccentric_nz.TARDIS.commands.preferences;
 
+import com.google.common.collect.ImmutableList;
 import me.eccentric_nz.TARDIS.TARDIS;
 import me.eccentric_nz.TARDIS.blueprints.TARDISPermission;
 import me.eccentric_nz.TARDIS.commands.TARDISCommandHelper;
@@ -33,7 +34,6 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -50,48 +50,28 @@ import java.util.Locale;
 public class TARDISPrefsCommands implements CommandExecutor {
 
     private final TARDIS plugin;
-    private final List<String> firstArgs = new ArrayList<>();
+    private static final ImmutableList<String> firstArgs = ImmutableList.of(
+        "auto", "auto_powerup", "auto_rescue", "auto_siege",
+        "beacon", "build",
+        "close_gui",
+        "difficulty", "dnd",
+        "eps", "eps_message",
+        "farm", "flight", "floor", "forcefield",
+        "hads", "hads_type", "hum",
+        "isomorphic",
+        "key", "key_menu",
+        "junk",
+        "language", "lanterns", "lock_containers",
+        "minecart",
+        "quotes",
+        "renderer",
+        "sfx", "siege_floor", "siege_wall", "sign", "sonic", "submarine",
+        "telepathy", "travelbar",
+        "wall", "wool_lights"
+    );
 
     public TARDISPrefsCommands(TARDIS plugin) {
         this.plugin = plugin;
-        firstArgs.add("auto");
-        firstArgs.add("auto_powerup");
-        firstArgs.add("auto_rescue");
-        firstArgs.add("auto_siege");
-        firstArgs.add("beacon");
-        firstArgs.add("build");
-        firstArgs.add("close_gui");
-        firstArgs.add("difficulty");
-        firstArgs.add("dnd");
-        firstArgs.add("eps");
-        firstArgs.add("eps_message");
-        firstArgs.add("farm");
-        firstArgs.add("flight");
-        firstArgs.add("floor");
-        firstArgs.add("forcefield");
-        firstArgs.add("hads");
-        firstArgs.add("hads_type");
-        firstArgs.add("hum");
-        firstArgs.add("isomorphic");
-        firstArgs.add("key");
-        firstArgs.add("key_menu");
-        firstArgs.add("junk");
-        firstArgs.add("language");
-        firstArgs.add("lanterns");
-        firstArgs.add("lock_containers");
-        firstArgs.add("minecart");
-        firstArgs.add("quotes");
-        firstArgs.add("renderer");
-        firstArgs.add("sfx");
-        firstArgs.add("siege_floor");
-        firstArgs.add("siege_wall");
-        firstArgs.add("sign");
-        firstArgs.add("sonic");
-        firstArgs.add("submarine");
-        firstArgs.add("telepathy");
-        firstArgs.add("travelbar");
-        firstArgs.add("wall");
-        firstArgs.add("wool_lights");
     }
 
     @Override
@@ -114,6 +94,10 @@ public class TARDISPrefsCommands implements CommandExecutor {
             String pref = args[0].toLowerCase(Locale.ENGLISH);
             if (firstArgs.contains(pref)) {
                 if (TARDISPermission.hasPermission(player, "tardis.timetravel")) {
+                    if (TARDISPermission.isNegated(player, "tardis.prefs." + pref)) {
+                        TARDISMessage.send(player, "NO_PERMS");
+                        return true;
+                    }
                     if (pref.equals("sonic")) {
                         // open sonic prefs menu
                         ItemStack[] sonics = new TARDISSonicMenuInventory(plugin).getMenu();
@@ -204,5 +188,14 @@ public class TARDISPrefsCommands implements CommandExecutor {
             }
         }
         return false;
+    }
+
+    /**
+     * Returns all the root arguments for the command.
+     *
+     * @return a list of root arguments
+     */
+    public static ImmutableList<String> getRootArgs() {
+        return firstArgs;
     }
 }

--- a/src/main/java/me/eccentric_nz/TARDIS/commands/preferences/TARDISPrefsTabComplete.java
+++ b/src/main/java/me/eccentric_nz/TARDIS/commands/preferences/TARDISPrefsTabComplete.java
@@ -33,8 +33,7 @@ import java.util.List;
  * TabCompleter for /tardisprefs
  */
 public class TARDISPrefsTabComplete extends TARDISCompleter implements TabCompleter {
-
-    private final ImmutableList<String> ROOT_SUBS = ImmutableList.of("auto", "auto_powerup", "auto_rescue", "auto_siege", "build", "beacon", "close_gui", "difficulty", "dnd", "eps", "eps_message", "farm", "flight", "floor", "forcefield", "hads", "hads_type", "hum", "isomorphic", "junk", "key", "key_menu", "language", "lanterns", "lock_containers", "minecart", "quotes", "renderer", "sfx", "siege_floor", "siege_wall", "sign", "sonic", "submarine", "telepathy", "travelbar", "wall", "wool_lights");
+    private final ImmutableList<String> ROOT_SUBS = TARDISPrefsCommands.getRootArgs();
     private final ImmutableList<String> DIFF_SUBS = ImmutableList.of("easy", "hard");
     private final ImmutableList<String> ONOFF_SUBS = ImmutableList.of("on", "off");
     private final ImmutableList<String> HADS_SUBS = ImmutableList.of("DISPLACEMENT", "DISPERSAL");


### PR DESCRIPTION
Also cleans up code a little bit.

This adds a way to _negate_ specific tardis.prefs WITHOUT needing to require them. 