### PR TITLE
#692 Make adaptive biome Chameleon presets configurable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>me.eccentric_nz.TARDIS</groupId>
     <artifactId>TARDIS</artifactId>
-    <version>4.12.0</version>
+    <version>4.12.1</version>
     <name>TARDIS</name>
     <description>A Doctor Who Plugin</description>
     <properties>

--- a/src/main/java/me/eccentric_nz/TARDIS/builders/TARDISPresetBuilderFactory.java
+++ b/src/main/java/me/eccentric_nz/TARDIS/builders/TARDISPresetBuilderFactory.java
@@ -195,27 +195,11 @@ public class TARDISPresetBuilderFactory {
         if (adaption.equals(Adaption.BLOCK)) {
             return PRESET.ADAPTIVE;
         } else {
-            return switch (biome) {
-                case BEACH, FROZEN_RIVER, RIVER, SNOWY_BEACH, STONY_SHORE -> PRESET.BOAT;
-                case COLD_OCEAN, DEEP_COLD_OCEAN, DEEP_LUKEWARM_OCEAN, DEEP_OCEAN, FROZEN_OCEAN, LUKEWARM_OCEAN, OCEAN, WARM_OCEAN -> PRESET.YELLOW;
-                case DESERT -> PRESET.DESERT;
-                case WINDSWEPT_GRAVELLY_HILLS, WINDSWEPT_HILLS, WINDSWEPT_FOREST -> PRESET.EXTREME_HILLS;
-                case BIRCH_FOREST, FOREST, OLD_GROWTH_BIRCH_FOREST -> PRESET.FOREST;
-                case NETHER_WASTES, SOUL_SAND_VALLEY, CRIMSON_FOREST, WARPED_FOREST, BASALT_DELTAS -> PRESET.NETHER;
-                case SNOWY_PLAINS, DEEP_FROZEN_OCEAN -> PRESET.ICE_FLATS;
-                case ICE_SPIKES -> PRESET.ICE_SPIKES;
-                case JUNGLE, SPARSE_JUNGLE, BAMBOO_JUNGLE -> PRESET.JUNGLE;
-                case BADLANDS, WOODED_BADLANDS, ERODED_BADLANDS -> PRESET.MESA;
-                case MUSHROOM_FIELDS -> PRESET.SHROOM;
-                case PLAINS, SUNFLOWER_PLAINS, MEADOW -> PRESET.PLAINS;
-                case DARK_FOREST, FLOWER_FOREST -> PRESET.ROOFED_FOREST;
-                case SAVANNA, WINDSWEPT_SAVANNA, SAVANNA_PLATEAU -> PRESET.SAVANNA;
-                case SWAMP -> PRESET.SWAMP;
-                case END_BARRENS, END_HIGHLANDS, END_MIDLANDS, SMALL_END_ISLANDS, THE_END -> PRESET.THEEND;
-                case OLD_GROWTH_SPRUCE_TAIGA, TAIGA, OLD_GROWTH_PINE_TAIGA -> PRESET.TAIGA;
-                case SNOWY_TAIGA, SNOWY_SLOPES, GROVE -> PRESET.COLD_TAIGA;
-                default -> PRESET.FACTORY;
-            };
+            try {
+                return PRESET.valueOf(plugin.getAdaptiveConfig().getString(biome.toString()));
+            } catch (IllegalArgumentException e) {
+                return PRESET.FACTORY;
+            }
         }
     }
 

--- a/src/main/java/me/eccentric_nz/TARDIS/files/TARDISFileCopier.java
+++ b/src/main/java/me/eccentric_nz/TARDIS/files/TARDISFileCopier.java
@@ -111,6 +111,8 @@ public class TARDISFileCopier {
         // The PYRAMID schematic designed by airomis (player at thatsnotacreeper.com)
         // The ENDER schematic designed by ToppanaFIN (player at thatsnotacreeper.com)
         // The MASTER's schematic designed by ShadowAssociate
+        // The FUGITIVE schematic based on a design by DT10 - https://www.youtube.com/watch?v=aykwXVemSs8
+        // The MECHANICAL schematic adapted from a design by Plastic Straw https://www.planetminecraft.com/data-pack/new-tardis-mod-mechanical-interior-datapack/
         // load schematic files - copy the default files if they don't exist
         String basepath = plugin.getDataFolder() + File.separator + "schematics" + File.separator;
         String userbasepath = plugin.getDataFolder() + File.separator + "user_schematics" + File.separator;

--- a/src/main/resources/adaptive.yml
+++ b/src/main/resources/adaptive.yml
@@ -1,0 +1,94 @@
+# beach, shore & river biomes
+#
+# `&beach` defines an alias to the `BOAT` preset
+# `*beach` is an instance of the alias
+# you can either change the alias `&beach` to another Chameleon preset
+# and the other instances will use that as well,
+# or set a preset for each individual biome
+BEACH: &beach BOAT
+FROZEN_RIVER: *beach
+RIVER: *beach
+SNOWY_BEACH: *beach
+STONY_SHORE: *beach
+# ocean biomes
+COLD_OCEAN: &sub YELLOW
+DEEP_COLD_OCEAN: *sub
+DEEP_LUKEWARM_OCEAN: *sub
+DEEP_OCEAN: *sub
+LUKEWARM_OCEAN: *sub
+OCEAN: *sub
+WARM_OCEAN: *sub
+# desert biome
+DESERT: DESERT
+# hill biomes
+WINDSWEPT_GRAVELLY_HILLS: &hills EXTREME_HILLS
+WINDSWEPT_HILLS: *hills
+WINDSWEPT_FOREST: *hills
+STONY_PEAKS: *hills
+# forest biomes
+BIRCH_FOREST: &forest FOREST
+FOREST: *forest
+OLD_GROWTH_BIRCH_FOREST: *forest
+# nether biomes
+NETHER_WASTES: &nether NETHER
+SOUL_SAND_VALLEY: *nether
+CRIMSON_FOREST: *nether
+WARPED_FOREST: *nether
+BASALT_DELTAS: *nether
+# frozen biomes
+SNOWY_PLAINS: &ice ICE_FLATS
+DEEP_FROZEN_OCEAN: *ice
+FROZEN_OCEAN: *ice
+JAGGED_PEAKS: *ice
+SNOWY_PEAKS: *ice
+# ice spikes biome
+ICE_SPIKES: ICE_SPIKES
+# jungle biomes
+JUNGLE: &jungle JUNGLE
+SPARSE_JUNGLE: *jungle
+BAMBOO_JUNGLE: *jungle
+# mesa biomes
+BADLANDS: &mesa MESA
+WOODED_BADLANDS: *mesa
+ERODED_BADLANDS: *mesa
+# mycelium biome
+MUSHROOM_FIELDS: SHROOM
+# plains biomes
+PLAINS: &plains PLAINS
+SUNFLOWER_PLAINS: *plains
+MEADOW: *plains
+# dark forest biomes
+DARK_FOREST: &dark ROOFED_FOREST
+FLOWER_FOREST: *dark
+# savanna biomes
+SAVANNA: &savanna SAVANNA
+WINDSWEPT_SAVANNA: *savanna
+SAVANNA_PLATEAU: *savanna
+# swamp biomes
+SWAMP: &swamp SWAMP;
+MANGROVE_SWAMP: *swamp
+# the end biomes
+END_BARRENS: &end THEEND
+END_HIGHLANDS: *end
+END_MIDLANDS: *end
+SMALL_END_ISLANDS: *end
+THE_END: *end
+# taiga biomes
+OLD_GROWTH_SPRUCE_TAIGA: &taiga TAIGA
+TAIGA: *taiga
+OLD_GROWTH_PINE_TAIGA: *taiga
+# snowy biomes
+#
+# `&snowy` defines an alias to the `COLD_TAIGA` preset
+# `*snowy` is an instance of the alias
+# you can either change the alias `&snowy` to another Chameleon preset
+# e.g. `&snowy PINE`
+# and the other instances will use that as well,
+# or set a preset for each individual biome
+SNOWY_TAIGA: &snowy COLD_TAIGA
+SNOWY_SLOPES: *snowy
+GROVE: *snowy
+# cave biomes
+DEEP_DARK: &cave CAVE
+LUSH_CAVES: *cave
+DRIPSTONE_CAVES: *cave


### PR DESCRIPTION
Edit _adaptive.yml_ to set the preset for each biome The file uses YAML aliases for example:

```yaml
# snowy biomes
SNOWY_TAIGA: &snowy COLD_TAIGA
SNOWY_SLOPES: *snowy
```

`&snowy` defines an alias to the `COLD_TAIGA` preset `*snowy` is an instance of the alias

You can either change the alias `&snowy` to another Chameleon preset e.g. `&snowy PINE`, and the other instances will use that as well, or set a preset for each individual biome.