### PR TITLE
Fix chemistry module always disabling

### DIFF
--- a/src/main/java/me/eccentric_nz/TARDIS/files/TARDISConfiguration.java
+++ b/src/main/java/me/eccentric_nz/TARDIS/files/TARDISConfiguration.java
@@ -357,9 +357,12 @@ public class TARDISConfiguration {
             i++;
         }
         // switch chemistry to a module
-        if (!config.contains("allow.chemistry")) {
+        if (config.contains("allow.chemistry")) {
             boolean tf = config.getBoolean("allow.chemistry");
-            plugin.getConfig().set("modules.chemistry", tf);
+            if (!config.contains("modules.chemistry") || config.getBoolean("modules.chemistry") != tf) {
+                plugin.getConfig().set("modules.chemistry", tf);
+            }
+            plugin.getConfig().set("allow.chemistry", null);
             i++;
         }
         if (i > 0) {


### PR DESCRIPTION
1. Checks if `allow.chemistry` is in the file. If it doesn't, skip
2. Checks if `modules.chemistry` is in the file. if it's not, add it with the value of `allow.chemistry`
3. Sets `modules.chemistry` to `allow.chemistry`
4. Remove `allow.chemistry1

Will make a wiki PR indicating this is a module that needs to be enabled. Was not aware.