### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -65,7 +65,7 @@ jobs:
 
     - name: Upload build artifacts to release
       id: update_release
-      uses: softprops/action-gh-release@v2.6.1
+      uses: softprops/action-gh-release@v3.0.0
       with:
         token: ${{ secrets.TARDIS_WORKFLOW }}
         tag_name: "${{ env.RELEASE_TAG }}"


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[softprops/action-gh-release](https://github.com/softprops/action-gh-release)** published a new release **[v3.0.0](https://github.com/softprops/action-gh-release/releases/tag/v3.0.0)** on 2026-04-12T04:46:49Z
