### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -99,7 +99,7 @@ jobs:
         echo "today=$(date +'%d %B %Y %H:%M')" >> $GITHUB_OUTPUT
 
     - name: Send Discord notification
-      uses: stegzilla/discord-notify@v4
+      uses: stegzilla/discord-notify@v5
       with:
         webhook_url: ${{ secrets.DISCORD_WEBHOOK_URL }}
         title: TARDIS Plugin Update


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[stegzilla/discord-notify](https://github.com/stegzilla/discord-notify)** published a new release **[v5](https://github.com/stegzilla/discord-notify/releases/tag/v5)** on 2026-04-19T13:33:26Z
