### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -76,7 +76,7 @@ jobs:
         append_body: true
 
     - name: Modrinth Publish
-      uses: cloudnode-pro/modrinth-publish@v2.3.4
+      uses: cloudnode-pro/modrinth-publish@v2.4.0
       with:
         token: ${{ secrets.MODRINTH_TOKEN }} # Modrinth API token
         project: 'ymLTIuUH' #  ID of the project this version is for


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[cloudnode-pro/modrinth-publish](https://github.com/cloudnode-pro/modrinth-publish)** published a new release **[v2.4.0](https://github.com/cloudnode-pro/modrinth-publish/releases/tag/v2.4.0)** on 2026-05-21T09:03:07Z
