### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -33,7 +33,7 @@ jobs:
         echo "EOF" >> $GITHUB_ENV
 
     - name: Set up JDK 25
-      uses: actions/setup-java@v5.3.0
+      uses: actions/setup-java@v5.4.0
       with:
         java-version: '25'
         distribution: 'temurin'
@@ -76,7 +76,7 @@ jobs:
         append_body: true
 
     - name: Modrinth Publish
-      uses: cloudnode-pro/modrinth-publish@v2.4.1
+      uses: cloudnode-pro/modrinth-publish@v2.5.0
       with:
         token: ${{ secrets.MODRINTH_TOKEN }} # Modrinth API token
         project: 'ymLTIuUH' #  ID of the project this version is for


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[cloudnode-pro/modrinth-publish](https://github.com/cloudnode-pro/modrinth-publish)** published a new release **[v2.5.0](https://github.com/cloudnode-pro/modrinth-publish/releases/tag/v2.5.0)** on 2026-06-23T07:28:03Z
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release **[v5.4.0](https://github.com/actions/setup-java/releases/tag/v5.4.0)** on 2026-06-25T15:38:03Z
