### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -33,7 +33,7 @@ jobs:
         echo "EOF" >> $GITHUB_ENV
 
     - name: Set up JDK 25
-      uses: actions/setup-java@v5.4.0
+      uses: actions/setup-java@v5.5.0
       with:
         java-version: '25'
         distribution: 'temurin'
@@ -66,7 +66,7 @@ jobs:
 
     - name: Upload build artifacts to release
       id: update_release
-      uses: softprops/action-gh-release@v3.0.1
+      uses: softprops/action-gh-release@v3.0.2
       with:
         token: ${{ secrets.TARDIS_WORKFLOW }}
         tag_name: "${{ env.RELEASE_TAG }}"


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[softprops/action-gh-release](https://github.com/softprops/action-gh-release)** published a new release **[v3.0.2](https://github.com/softprops/action-gh-release/releases/tag/v3.0.2)** on 2026-07-13T14:30:35Z
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release **[v5.5.0](https://github.com/actions/setup-java/releases/tag/v5.5.0)** on 2026-07-07T20:32:28Z
