### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -33,7 +33,7 @@ jobs:
         echo "EOF" >> $GITHUB_ENV
 
     - name: Set up JDK 25
-      uses: actions/setup-java@v5.5.0
+      uses: actions/setup-java@v5.6.0
       with:
         java-version: '25'
         distribution: 'temurin'


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release **[v5.6.0](https://github.com/actions/setup-java/releases/tag/v5.6.0)** on 2026-07-16T14:46:41Z
