### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -21,7 +21,7 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v7.0.0
+    - uses: actions/checkout@v7.0.1
       with:
         fetch-depth: 0
 
@@ -33,7 +33,7 @@ jobs:
         echo "EOF" >> $GITHUB_ENV
 
     - name: Set up JDK 25
-      uses: actions/setup-java@v5.6.0
+      uses: actions/setup-java@v5.7.0
       with:
         java-version: '25'
         distribution: 'temurin'
@@ -45,7 +45,7 @@ jobs:
     # Configure Gradle for optimal use in GitHub Actions, including caching of downloaded dependencies.
     # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v6.2.0
+      uses: gradle/actions/setup-gradle@v6.3.0
     
     # set executable permissions on gradlew
     - name: Grant execute permission for gradlew
@@ -76,7 +76,7 @@ jobs:
         append_body: true
 
     - name: Modrinth Publish
-      uses: cloudnode-pro/modrinth-publish@v2.5.0
+      uses: cloudnode-pro/modrinth-publish@v2.5.1
       with:
         token: ${{ secrets.MODRINTH_TOKEN }} # Modrinth API token
         project: 'ymLTIuUH' #  ID of the project this version is for

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7.0.1
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.TARDIS_ACTIONS }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v7.0.1](https://github.com/actions/checkout/releases/tag/v7.0.1)** on 2026-07-20T15:10:05Z
* **[gradle/actions](https://github.com/gradle/actions)** published a new release **[v6.3.0](https://github.com/gradle/actions/releases/tag/v6.3.0)** on 2026-08-02T19:51:42Z
* **[cloudnode-pro/modrinth-publish](https://github.com/cloudnode-pro/modrinth-publish)** published a new release **[v2.5.1](https://github.com/cloudnode-pro/modrinth-publish/releases/tag/v2.5.1)** on 2026-08-05T18:14:10Z
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release **[v5.7.0](https://github.com/actions/setup-java/releases/tag/v5.7.0)** on 2026-07-31T19:41:06Z
